### PR TITLE
Flattened PostalError

### DIFF
--- a/Postal.xcodeproj/project.pbxproj
+++ b/Postal.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		F71325661D50CA84005DFC15 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71325651D50CA84005DFC15 /* Configuration.swift */; };
 		F71325671D50CA84005DFC15 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71325651D50CA84005DFC15 /* Configuration.swift */; };
 		F75DD4751D4BAC1500D40E9C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F75DD4741D4BAC1500D40E9C /* Result.framework */; };
+		F7E884A61D59C7F500D02CC2 /* PostalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E884A51D59C7F500D02CC2 /* PostalError.swift */; };
+		F7E884A71D59C7F500D02CC2 /* PostalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E884A51D59C7F500D02CC2 /* PostalError.swift */; };
 		F7F03C781D4BA5A90083397F /* Address+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F039F51D4BA5A70083397F /* Address+Parsing.swift */; };
 		F7F03C7A1D4BA5A90083397F /* CertificateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F039F71D4BA5A70083397F /* CertificateUtils.swift */; };
 		F7F03C7B1D4BA5A90083397F /* ContentDisposition+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F039F81D4BA5A70083397F /* ContentDisposition+Parsing.swift */; };
@@ -169,6 +171,7 @@
 		98DB04381CEC7342003CAABB /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 		F71325651D50CA84005DFC15 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		F75DD4741D4BAC1500D40E9C /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7E884A51D59C7F500D02CC2 /* PostalError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostalError.swift; sourceTree = "<group>"; };
 		F7F039F51D4BA5A70083397F /* Address+Parsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Address+Parsing.swift"; sourceTree = "<group>"; };
 		F7F039F71D4BA5A70083397F /* CertificateUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CertificateUtils.swift; sourceTree = "<group>"; };
 		F7F039F81D4BA5A70083397F /* ContentDisposition+Parsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContentDisposition+Parsing.swift"; sourceTree = "<group>"; };
@@ -343,6 +346,7 @@
 			isa = PBXGroup;
 			children = (
 				F7F03C741D4BA5A90083397F /* Postal.swift */,
+				F7E884A51D59C7F500D02CC2 /* PostalError.swift */,
 				F71325651D50CA84005DFC15 /* Configuration.swift */,
 			);
 			name = Postal;
@@ -631,6 +635,7 @@
 				9812C3251D509B5300630D46 /* Logger.swift in Sources */,
 				9812C32E1D509B6400630D46 /* MessageAttribute+Parsing.swift in Sources */,
 				9812C33A1D509B6400630D46 /* IMAPSession+Fetch.swift in Sources */,
+				F7E884A71D59C7F500D02CC2 /* PostalError.swift in Sources */,
 				9812C33B1D509B6400630D46 /* IMAPSession+Search.swift in Sources */,
 				9812C32D1D509B6400630D46 /* Message+Parsing.swift in Sources */,
 				F71325671D50CA84005DFC15 /* Configuration.swift in Sources */,
@@ -678,6 +683,7 @@
 				F7F03C7C1D4BA5A90083397F /* ContentEncoding+Parsing.swift in Sources */,
 				F7F03EAC1D4BA5A90083397F /* Message+Parsing.swift in Sources */,
 				F7F03EAE1D4BA5A90083397F /* MessageFlags+Parsing.swift in Sources */,
+				F7E884A61D59C7F500D02CC2 /* PostalError.swift in Sources */,
 				F7F03EB61D4BA5A90083397F /* Util.swift in Sources */,
 				F7F03C871D4BA5A90083397F /* IMAPSession+Fetch.swift in Sources */,
 				F71325661D50CA84005DFC15 /* Configuration.swift in Sources */,

--- a/Postal/IMAPSession.swift
+++ b/Postal/IMAPSession.swift
@@ -160,7 +160,7 @@ final class IMAPSession {
             result = mailimap_login(imap, configuration.login, password)
         }
         
-        try result.toIMAPError?.enrich { return .loginError(String.fromCString(imap.memory.imap_response) ?? "") }.check()
+        try result.toIMAPError?.enrich { return .login(description: String.fromCString(imap.memory.imap_response) ?? "") }.check()
         
         try checkCapabilities()
     }
@@ -193,7 +193,7 @@ final class IMAPSession {
             
             let initialFolders = makeFolders(sequence(list, of: mailimap_mailbox_list.self))
             
-            guard let initialFolder = initialFolders.first else { throw IMAPError.loginError("").asPostalError }
+            guard let initialFolder = initialFolders.first else { throw IMAPError.login(description: "").asPostalError }
             
             defaultNamespace = IMAPNamespace(items: [ IMAPNamespaceItem(prefix: "", delimiter: initialFolder.delimiter) ])
         }
@@ -218,7 +218,7 @@ final class IMAPSession {
             try mailimap_select(imap, folder).toIMAPError?.check()
         }
         
-        guard let info = imap.optional?.imap_selection_info.optional else { throw IMAPError.nonExistantFolderError.asPostalError }
+        guard let info = imap.optional?.imap_selection_info.optional else { throw IMAPError.nonExistantFolder.asPostalError }
         
         // store last selected folder
         selectedFolder = folder
@@ -256,7 +256,7 @@ final class IMAPSession {
     
     private func checkCertificateIfNeeded() throws -> Bool {
         guard configuration.checkCertificateEnabled else { return true }
-        guard checkCertificate(imap.memory.imap_stream, hostname: configuration.hostname) else { throw IMAPError.certificateError.asPostalError }
+        guard checkCertificate(imap.memory.imap_stream, hostname: configuration.hostname) else { throw IMAPError.certificate.asPostalError }
         return true
     }
 }

--- a/Postal/IMFError.swift
+++ b/Postal/IMFError.swift
@@ -25,19 +25,23 @@
 import Foundation
 import libetpan
 
-public enum IMFError {
-    case undefinedError
+enum IMFError {
+    case undefined
 }
 
 extension IMFError: PostalErrorType {
-    var asPostalError: PostalError { return .imfError(self) }
+    var asPostalError: PostalError {
+        switch self {
+        case .undefined: return .undefined
+        }
+    }
 }
 
 extension Int {
     var toIMFError: IMFError? {
         switch self {
         case MAILIMF_NO_ERROR: return nil
-        default: return .undefinedError
+        default: return .undefined
         }
     }
 }

--- a/Postal/Postal.swift
+++ b/Postal/Postal.swift
@@ -25,19 +25,6 @@
 import Foundation
 import Result
 
-protocol PostalErrorType {
-    var asPostalError: PostalError { get }
-}
-
-extension PostalErrorType {
-    func check() throws { throw self.asPostalError }
-}
-
-public enum PostalError: ErrorType {
-    case imapError(IMAPError)
-    case imfError(IMFError)
-}
-
 /// This class is the class where every request will be performed.
 public class Postal {
     private let session: IMAPSession


### PR DESCRIPTION
`imapError` and `imfError` cases had too much complexity for `PostalError`. So I moved them as internal types and duplicate their cases in `PostalError`. For future, the protocol `PostalErrorType` will help us to maintain internal types and the conversion `IMAPError/IMFError` -> `PostalError`.